### PR TITLE
Fix bad memory locality

### DIFF
--- a/include/LCContentFast/ConeClusteringAlgorithmFast.h
+++ b/include/LCContentFast/ConeClusteringAlgorithmFast.h
@@ -81,7 +81,7 @@ private:
      */
     pandora::StatusCode SeedClustersWithTracks(const pandora::TrackList *const pTrackList, pandora::ClusterVector &clusterVector);
 
-    typedef std::map<const pandora::Cluster*, const pandora::ClusterFitResult> ClusterFitResultMap;
+    typedef std::unordered_map<const pandora::Cluster*, const pandora::ClusterFitResult> ClusterFitResultMap;
     typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 4> HitKDTree;
     typedef KDTreeNodeInfoT<const pandora::CaloHit*, 4> HitKDNode;
     typedef KDTreeLinkerAlgo<const pandora::Track*, 3> TrackKDTree;

--- a/src/LCContentFast/MainFragmentRemovalAlgorithmFast.cc
+++ b/src/LCContentFast/MainFragmentRemovalAlgorithmFast.cc
@@ -204,6 +204,9 @@ StatusCode MainFragmentRemovalAlgorithm::Run()
         hits_in_cluster.clear();
         neighbours.clear();
     }
+    // zero out hits_in_cluster and found_hits ( neighbours is already taken care of by the std::move() )
+    hits_in_cluster = std::move(CaloHitList());
+    found_hits = std::move(std::vector<HitKDNodeByIndex>());
 
     while (shouldRecalculate)
     {


### PR DESCRIPTION
Fixed the worse instances of poor memory locality in LCContentFast, pointed out by igprof.
Local testing on CMS data indicates no changes to physics performance, as there were none expected.

This is mainly done by pulling result caches out of loops and using .clear() to zero the size, but not the capacity, of containers.

No major speed improvements but:
- improves (reduces) RSS footprint for jobs
- large reduction in the number of allocations